### PR TITLE
Fix paragraph rendering

### DIFF
--- a/src/formatters.js
+++ b/src/formatters.js
@@ -94,7 +94,7 @@ function replaceOl (doc) {
  * @return {String}           [description]
  */
 function replaceParagraph (doc) {
-  return makeRegex(pRegex, doc);
+  return makeRegex(pRegex, doc, '', '\n\n');
 }
 
 /**


### PR DESCRIPTION
Paragraphs are defined in markdown with an empty break line between 2 lines of text